### PR TITLE
vendor: add changelog script

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -69,10 +69,6 @@ ifneq ($(TARGET_BUILD_VARIANT),eng)
 ADDITIONAL_DEFAULT_PROPERTIES += ro.adb.secure=1
 endif
 
-# Copy over the changelog to the device
-PRODUCT_COPY_FILES += \
-    vendor/cm/CHANGELOG.mkdn:system/etc/RR/Changelog.txt
-
 # Copy features.txt from the path
 PRODUCT_COPY_FILES += \
     vendor/cm/Features.mkdn:system/etc/RR/Features.txt

--- a/tools/changelog
+++ b/tools/changelog
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Exports
+
+. $ANDROID_BUILD_TOP/vendor/cm/tools/colors
+
+export Changelog=Changelog.txt
+
+if [ -f $Changelog ];
+then
+	rm -f $Changelog
+fi
+
+touch $Changelog
+
+# Print something to build output
+echo ${bldppl}"Generating changelog..."${txtrst}
+
+for i in $(seq 14);
+do
+export After_Date=`date --date="$i days ago" +%m-%d-%Y`
+k=$(expr $i - 1)
+	export Until_Date=`date --date="$k days ago" +%m-%d-%Y`
+
+	# Line with after --- until was too long for a small ListView
+	echo '====================' >> $Changelog;
+	echo  "     "$Until_Date    >> $Changelog;
+	echo '====================' >> $Changelog;
+	# Cycle through every repo to find commits between 2 dates
+	repo forall -pc 'git log --pretty=format:"%h  %s  [%cn]" --decorate --after=$After_Date --until=$Until_Date' >> $Changelog
+	echo >> $Changelog;
+        echo >> $Changelog;
+done
+
+sed -i 's/project/   */g' $Changelog
+
+cp $Changelog $OUT/system/etc/RR/
+cp $Changelog $OUT/
+rm $Changelog
+


### PR DESCRIPTION
All credits to the original author(s), no clue who it (they?) actually are

To use it,
. build/envsetup.sh
breakfast/lunch your device
./vendor/cm/tools/changelog
Will generate changelog with 14 days worth of commits

Signed-off-by: Akhil Narang <akhil.narang@protonmail.com>